### PR TITLE
Do not segfault if camera initialization fails in constructor.

### DIFF
--- a/andorApp/src/andorCCD.cpp
+++ b/andorApp/src/andorCCD.cpp
@@ -718,6 +718,7 @@ asynStatus AndorCCD::setupShutter(int command)
   int openTime, closeTime;
   int shutterExTTL;
   int shutterMode;
+  AndorCapabilities capabilities;
   asynStatus status=asynSuccess;
   static const char *functionName = "setupShutter";
   
@@ -750,11 +751,14 @@ asynStatus AndorCCD::setupShutter(int command)
   }
 
   try {
-    asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW, 
-      "%s:%s:, SetShutter(%d,%d,%d,%d)\n", 
-      driverName, functionName, shutterExTTL, shutterMode, closeTime, openTime);
-    checkStatus(SetShutter(shutterExTTL, shutterMode, closeTime, openTime)); 
-
+    capabilities.ulSize = sizeof(capabilities);
+    checkStatus(GetCapabilities(&capabilities));
+    if (capabilities.ulFeatures & AC_FEATURES_SHUTTER) {
+      asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW,
+        "%s:%s:, SetShutter(%d,%d,%d,%d)\n",
+        driverName, functionName, shutterExTTL, shutterMode, closeTime, openTime);
+      checkStatus(SetShutter(shutterExTTL, shutterMode, closeTime, openTime));
+    }
   } catch (const std::string &e) {
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
       "%s:%s: %s\n",

--- a/andorApp/src/andorCCD.cpp
+++ b/andorApp/src/andorCCD.cpp
@@ -850,6 +850,8 @@ unsigned int AndorCCD::checkStatus(unsigned int returnStatus)
     throw std::string("ERROR: Problem communicating with camera.");  
   } else if (returnStatus == DRV_LOAD_FIRMWARE_ERROR) {
     throw std::string("ERROR: Error loading firmware.");  
+  } else if (returnStatus == DRV_NOT_SUPPORTED) {
+    throw std::string("ERROR: Feature not supported.");
   } else {
     sprintf(message, "ERROR: Unknown error code=%d returned from Andor SDK.", returnStatus);
     throw std::string(message);

--- a/andorApp/src/andorCCD.h
+++ b/andorApp/src/andorCCD.h
@@ -196,6 +196,8 @@ class AndorCCD : public ADDriver {
   tagCSMAHEAD *mSPEHeader;
   TiXmlDocument *mSPEDoc;
 
+  // Camera init status
+  bool mInitOK;
 };
 
 #define NUM_ANDOR_DET_PARAMS ((int)(&LAST_ANDOR_PARAM - &FIRST_ANDOR_PARAM + 1))


### PR DESCRIPTION
Move allocation of enum string before calling Andor SDK init.
mInitOK is used to avoid divide by zero in setupAcquisition().