### PR TITLE
Add support for Frame Transfer Mode, Vertical Shift Speed

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,6 +22,11 @@ files respectively, in the configure/ directory of the appropriate release of th
 
 Release Notes
 =============
+RX-X ()
+----
+* Added support for Frame Transfer mode.
+* Added support for setting the Vertical Shift Period.
+
 R2-6 (July 4, 2017)
 ----
 * Changed from using TinyXml to libxml2.  This is used when saving SPE files.  This change was made

--- a/andorApp/Db/andorCCD.template
+++ b/andorApp/Db/andorCCD.template
@@ -387,6 +387,25 @@ record(mbbi, "$(P)$(R)AndorReadOutMode_RBV")
    field(SCAN, "I/O Intr")
 }
 
+# Frame Transfer Mode
+record(bo, "$(P)$(R)AndorFTMode")
+{
+    field(PINI, "1")
+    field(DTYP, "asynInt32")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ANDOR_FT_MODE")
+}
+
+record(bi, "$(P)$(R)AndorFTMode_RBV")
+{
+    field(DTYP, "asynInt32")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ANDOR_FT_MODE")
+    field(SCAN, "I/O Intr")
+}
+
 #Records in ADBase that do not apply to Andor
 
 record(mbbo, "$(P)$(R)ColorMode")

--- a/andorApp/Db/andorCCD.template
+++ b/andorApp/Db/andorCCD.template
@@ -406,6 +406,21 @@ record(bi, "$(P)$(R)AndorFTMode_RBV")
     field(SCAN, "I/O Intr")
 }
 
+# The Vertical Shift Period enum values are constructed at run-time based on camera capabilities
+record(mbbo, "$(P)$(R)AndorVSPeriod")
+{
+    field(PINI, "1")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ANDOR_VS_PERIOD")
+}
+
+record(mbbi, "$(P)$(R)AndorVSPeriod_RBV")
+{
+   field(DTYP, "asynInt32")
+   field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))ANDOR_VS_PERIOD")
+   field(SCAN, "I/O Intr")
+}
+
 #Records in ADBase that do not apply to Andor
 
 record(mbbo, "$(P)$(R)ColorMode")

--- a/andorApp/Db/andorCCD_settings.req
+++ b/andorApp/Db/andorCCD_settings.req
@@ -10,6 +10,7 @@ $(P)$(R)AndorEMGainAdvanced
 $(P)$(R)AndorADCSpeed
 $(P)$(R)AndorReadOutMode
 $(P)$(R)AndorFTMode
+$(P)$(R)AndorVSPeriod
 file "ADBase_settings.req", P=$(P), R=$(R)
 file "NDFile_settings.req", P=$(P), R=$(R)
 

--- a/andorApp/Db/andorCCD_settings.req
+++ b/andorApp/Db/andorCCD_settings.req
@@ -9,6 +9,7 @@ $(P)$(R)AndorEMGainMode
 $(P)$(R)AndorEMGainAdvanced
 $(P)$(R)AndorADCSpeed
 $(P)$(R)AndorReadOutMode
+$(P)$(R)AndorFTMode
 file "ADBase_settings.req", P=$(P), R=$(R)
 file "NDFile_settings.req", P=$(P), R=$(R)
 

--- a/andorApp/src/andorCCD.cpp
+++ b/andorApp/src/andorCCD.cpp
@@ -668,7 +668,14 @@ asynStatus AndorCCD::writeInt32(asynUser *pasynUser, epicsInt32 value)
       status = setupShutter(-1);
     }
     else if (function == AndorBaselineClamp) {
-      checkStatus(SetBaselineClamp(value));
+      try {
+        checkStatus(SetBaselineClamp(value));
+      } catch (const std::string &e) {
+        asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
+          "%s:%s: %s\n",
+          driverName, functionName, e.c_str());
+        status = asynError;
+      }
     }
     else {
       status = ADDriver::writeInt32(pasynUser, value);

--- a/andorApp/src/andorCCD.h
+++ b/andorApp/src/andorCCD.h
@@ -35,6 +35,7 @@
 #define AndorAdcSpeedString                "ANDOR_ADC_SPEED"
 #define AndorBaselineClampString           "ANDOR_BASELINE_CLAMP"
 #define AndorReadOutModeString             "ANDOR_READOUT_MODE"
+#define AndorFrameTransferModeString       "ANDOR_FT_MODE"
 
 /**
  * Structure defining an ADC speed for the ADAndor driver.
@@ -97,7 +98,8 @@ class AndorCCD : public ADDriver {
   int AndorAdcSpeed;
   int AndorBaselineClamp;
   int AndorReadOutMode;
-  #define LAST_ANDOR_PARAM AndorReadOutMode
+  int AndorFrameTransferMode;
+  #define LAST_ANDOR_PARAM AndorFrameTransferMode
 
  private:
 

--- a/andorApp/src/andorCCD.h
+++ b/andorApp/src/andorCCD.h
@@ -20,6 +20,7 @@
 #define MAX_ENUM_STRING_SIZE 26
 #define MAX_ADC_SPEEDS 16
 #define MAX_PREAMP_GAINS 16
+#define MAX_VS_PERIODS 16
 
 #define AndorCoolerParamString             "ANDOR_COOLER"
 #define AndorTempStatusMessageString       "ANDOR_TEMP_STAT"
@@ -36,6 +37,7 @@
 #define AndorBaselineClampString           "ANDOR_BASELINE_CLAMP"
 #define AndorReadOutModeString             "ANDOR_READOUT_MODE"
 #define AndorFrameTransferModeString       "ANDOR_FT_MODE"
+#define AndorVerticalShiftPeriodString     "ANDOR_VS_PERIOD"
 
 /**
  * Structure defining an ADC speed for the ADAndor driver.
@@ -60,6 +62,16 @@ typedef struct {
   char *EnumString;
   int EnumValue;
 } AndorPreAmpGain_t;
+
+/*
+ * Structure defining a Vertical Shift Period for the ADAndor driver.
+ */
+typedef struct {
+  float Period;
+  int Index;
+  char *EnumString;
+  int EnumValue;
+} AndorVSPeriod_t;
 
 /**
  * Driver for Andor CCD cameras using version 2 of their SDK; inherits from ADDriver class in ADCore.
@@ -99,7 +111,8 @@ class AndorCCD : public ADDriver {
   int AndorBaselineClamp;
   int AndorReadOutMode;
   int AndorFrameTransferMode;
-  #define LAST_ANDOR_PARAM AndorFrameTransferMode
+  int AndorVerticalShiftPeriod;
+  #define LAST_ANDOR_PARAM AndorVerticalShiftPeriod
 
  private:
 
@@ -109,6 +122,7 @@ class AndorCCD : public ADDriver {
   void saveDataFrame(int frameNumber);
   void setupADCSpeeds();
   void setupPreAmpGains();
+  void setupVerticalShiftPeriods();
   unsigned int SaveAsSPE(char *fullFileName);
   /**
    * Additional image mode to those in ADImageMode_t
@@ -194,6 +208,13 @@ class AndorCCD : public ADDriver {
   int mTotalPreAmpGains;
   int mNumPreAmpGains;
   AndorPreAmpGain_t mPreAmpGains[MAX_PREAMP_GAINS];
+
+  // Vertical Shift Period parameters
+  int mTotalVSPeriods;
+  int mNumVSPeriods;
+  int mVSIndex;
+  float mVSPeriod;
+  AndorVSPeriod_t mVSPeriods[MAX_VS_PERIODS];
 
   //Shutter control parameters
   float mAcquireTime;

--- a/documentation/andorDoc.html
+++ b/documentation/andorDoc.html
@@ -48,11 +48,12 @@
     <li>Support for all of the Andor shutter modes</li>
     <li>Support for reading the detectors with 16-bit or 32-bit depth</li>
     <li>Saving files using the Andor SDK and/or with the standard areaDetector plugins</li>
-    <li>Change the ADC sampling speed (0.05MHz and 2.5MHz on the iKon)</li>
+    <li>Change the ADC sampling speed (0.05MHz and 2.5MHz on the iKon) and the Vertical Shift Period</li>
     <li>Set a region of interest (a smaller region can be read out faster)</li>
     <li>Set and monitor the CCD temperature</li>
     <li>Electron Multiplying (EM) Gain on supported detectors</li>
     <li>Support for selecting between Full Vertical Binning (FVB) and Image readout modes</li>
+    <li>Support for Frame Transfer mode</li>
   </ul>
   <p>
     The Andor module includes a separate driver to control the Andor Shamrock spectrographs.
@@ -712,6 +713,56 @@
         <td>
           AndorReadOutMode<br />
           AndorReadOutMode_RBV</td>
+        <td>
+          mbbo<br />
+          mbbi</td>
+      </tr>
+      <tr>
+        <td>
+          AndorFTMode</td>
+        <td>
+          asynInt32</td>
+        <td>
+          R/W</td>
+        <td>
+          Set Frame Transfer mode. Choices are:
+          <ul>
+            <li>Disabled</li>
+            <li>Enabled</li>
+          </ul>
+          Note: Only available on supported CCDs.
+        </td>
+        <td>
+          ANDOR_FT_MODE</td>
+        <td>
+          AndorFTMode<br />
+          AndorFTMode_RBV</td>
+        <td>
+          bo<br />
+          bi</td>
+      </tr>
+      <tr>
+        <td>
+          AndorVSPeriod</td>
+        <td>
+          asynInt32</td>
+        <td>
+          R/W</td>
+        <td>
+          Sets Vetical Shift Period, in units of microseconds per pixel shift.<br/>
+          Choices are constructed at runtime. For example, the choices for an iDus are:
+          <ul>
+            <li>4.25 us</li>
+            <li>8.25 us</li>
+            <li>16.25 us</li>
+            <li>32.25 us</li>
+            <li>64.25 us</li>
+          </ul>
+        <td>
+          ANDOR_VS_PERIOD</td>
+        <td>
+          AndorVSPeriod<br />
+          AndorVSPeriod_RBV</td>
         <td>
           mbbo<br />
           mbbi</td>


### PR DESCRIPTION
Tested successfully on iDus and iXon 897 CCDs.

RHEL6, EPICS 3.15.5, asyn 4.33, busy 1.6.1, calc 3.6.1, autosave 5.7.1, seq 2.2.4, sscan 2.10.2

This also includes the following outstanding pull request:
Add try/catch block for call to BaselineClamp(). #11