### PR TITLE
use device serial number to select the camera (0 for any camera)

### DIFF
--- a/andorApp/src/andorCCD.h
+++ b/andorApp/src/andorCCD.h
@@ -79,7 +79,7 @@ typedef struct {
  */
 class AndorCCD : public ADDriver {
  public:
-  AndorCCD(const char *portName, const char *installPath, int cameraID, int shamrockID, 
+  AndorCCD(const char *portName, const char *installPath, int cameraSerial, int shamrockID,
            int maxBuffers, size_t maxMemory, int priority, int stackSize);
   virtual ~AndorCCD();
 

--- a/iocs/andorIOC/iocBoot/iocAndor/st.cmd
+++ b/iocs/andorIOC/iocBoot/iocAndor/st.cmd
@@ -15,10 +15,13 @@ epicsEnvSet("CBUFFS", "500")
 # The search path for database files
 epicsEnvSet("EPICS_DB_INCLUDE_PATH", "$(ADCORE)/db")
 
-# andorCCDConfig(const char *portName, const char *installPath, int cameraID, int shamrockID,
+# andorCCDConfig(const char *portName, const char *installPath, int cameraSerial, int shamrockID,
 #                int maxBuffers, size_t maxMemory, int priority, int stackSize)
 #andorCCDConfig("$(PORT)", "/usr/local/etc/andor/", 0, 0, 0, 0, 0 ,0)
-andorCCDConfig("$(PORT)", "", 0, 0, 0, 0, 0)
+# select the camera with serial number 1370
+#andorCCDConfig("$(PORT)", "", 1370, 0, 0, 0, 0, 0)
+# select a camera with any serial number
+andorCCDConfig("$(PORT)", "", 0, 0, 0, 0, 0, 0)
 
 dbLoadRecords("$(ADANDOR)/db/andorCCD.template",   "P=$(PREFIX),R=cam1:,PORT=$(PORT),ADDR=0,TIMEOUT=1")
 


### PR DESCRIPTION
Tested with two cameras, on two distinct IOCs, by supplying cameraSerial number in the st.cmd.
Tested the case with supplied cameraSerial set to 0 (in st.cmd); will pick the first camera.