### PR TITLE
Temperature parameter is set on startup to current temperature. Inval…

### DIFF
--- a/andorApp/src/andorCCD.cpp
+++ b/andorApp/src/andorCCD.cpp
@@ -241,6 +241,13 @@ AndorCCD::AndorCCD(const char *portName, const char *installPath, int cameraSeri
     checkStatus(GetFastestRecommendedVSSpeed(&mVSIndex, &mVSPeriod));
     mCapabilities.ulSize = sizeof(mCapabilities);
     checkStatus(GetCapabilities(&mCapabilities));
+
+    /* Get current temperature */
+    float temperature;
+    checkStatus(GetTemperatureF(&temperature));
+    printf("%s:%s: current temperature is %f\n", driverName, functionName, temperature);
+    setDoubleParam(ADTemperature, temperature);
+
     callParamCallbacks();
   } catch (const std::string &e) {
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
@@ -766,6 +773,10 @@ asynStatus AndorCCD::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
     int minTemp = 0;
     int maxTemp = 0;
 
+    /* Store the old value */
+    epicsFloat64 oldValue;
+    getDoubleParam(function, &oldValue);
+
     /* Set the parameter and readback in the parameter library.  */
     status = setDoubleParam(function, value);
 
@@ -786,16 +797,21 @@ asynStatus AndorCCD::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
         "%s:%s:, Setting temperature value %f\n", 
         driverName, functionName, value);
       try {
+        /* Check requested temperature is within our range */
+        checkStatus(GetTemperatureRange(&minTemp, &maxTemp));
         asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW, 
           "%s:%s:, CCD Min Temp: %d, Max Temp %d\n", 
           driverName, functionName, minTemp, maxTemp);
-        checkStatus(GetTemperatureRange(&minTemp, &maxTemp));
-        if ((static_cast<int>(value) > minTemp) & (static_cast<int>(value) < maxTemp)) {
+        if ((static_cast<int>(value) >= minTemp) & (static_cast<int>(value) <= maxTemp)) {
           asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW, 
             "%s:%s:, SetTemperature(%d)\n", 
             driverName, functionName, static_cast<int>(value));
           checkStatus(SetTemperature(static_cast<int>(value)));
         } else {
+          /* Requested temperature is out of range */
+          status = setDoubleParam(function, oldValue);
+          asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW,
+            "Requested temperature out of range\n");
           setStringParam(AndorMessage, "Temperature is out of range.");
           callParamCallbacks();
           status = asynError;
@@ -811,24 +827,24 @@ asynStatus AndorCCD::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
              (function == ADShutterCloseDelay)) {             
       status = setupShutter(-1);
     }
-      
     else {
       status = ADDriver::writeFloat64(pasynUser, value);
     }
 
-    //For a successful write, clear the error message.
-    setStringParam(AndorMessage, " ");
-
     /* Do callbacks so higher layers see any changes */
     callParamCallbacks();
-    if (status)
+    if (status) {
         asynPrint(pasynUser, ASYN_TRACE_ERROR,
               "%s:%s: error, status=%d function=%d, value=%f\n",
               driverName, functionName, status, function, value);
-    else
+    }
+    else {
         asynPrint(pasynUser, ASYN_TRACEIO_DRIVER,
             "%s:%s: function=%d, value=%f\n",
             driverName, functionName, function, value);
+        /* For a successful write, clear the error message. */
+        setStringParam(AndorMessage, " ");
+    }
     return status;
 }
 


### PR DESCRIPTION
…id temperatures no longer update the parameter.

- This fixes #30 by reverting to the original value of ADTemperature if an invalid value is requested.

- I have also fixed the logging where it would print the flow message before the minimum and maximum temperature values have been queried.

- Additionally, I have moved the clearing of the "successful write" in writeFloat64 to actually only clear when the status is success.

- Finally, ADBase.template sets an initial value of the temperature to 25.0C at startup. This causes an error on many models of Andor cameras as the maximum temperature is usually 20C or lower. I have made a change so the current temperature is used as the initial value of the ADTemperature parameter. This may stop any current cooling/heating occurring as the IOC is started, but there isn't a separate setpoint temperature to read. Alternatively I could overwrite the ADBase.template Temperature PV so that PINI=NO and leave the parameter at 0 - but I wasn't sure which was the best option.