### PR TITLE
Added EpicsEvent so acquire callback happens after camera acquisition…

### DIFF
--- a/andorApp/src/andorCCD.h
+++ b/andorApp/src/andorCCD.h
@@ -198,6 +198,7 @@ class AndorCCD : public ADDriver {
 
   epicsEventId statusEvent;
   epicsEventId dataEvent;
+  epicsEventId acquireEvent;
   double mPollingPeriod;
   double mFastPollingPeriod;
   unsigned int mAcquiringData;


### PR DESCRIPTION
… has started

I have added an epicsEvent used by the writeInt32 function to wait for the camera acquisition to start before updating the Acquire parameter and calling callParamCallbacks.

This event is signalled by the data task after the acquisition has started on the camera.

This fixes #32 in my testing with an Andor iXon Ultra 897.