### PR TITLE
Now set ADAcquire parameter to 1 after detector acquisition has started

### DIFF
--- a/andorApp/src/andorCCD.cpp
+++ b/andorApp/src/andorCCD.cpp
@@ -627,18 +627,16 @@ asynStatus AndorCCD::writeInt32(asynUser *pasynUser, epicsInt32 value)
     asynStatus status = asynSuccess;
     static const char *functionName = "writeInt32";
 
-    // Set in param lib so the user sees a readback straight away. Save a backup in case of errors.
+    //Set in param lib so the user sees a readback straight away. Save a backup in case of errors.
     getIntegerParam(function, &oldValue);
     status = setIntegerParam(function, value);
 
     if (function == ADAcquire) {
       getIntegerParam(ADStatus, &adstatus);
-      // Temporarily set ADAcquire back to 0 until Acquisition is started by dataTask
-      status = setIntegerParam(ADAcquire, 0);
       if (value && (adstatus == ADStatusIdle)) {
         try {
           mAcquiringData = 1;
-          // We send an event at the bottom of this function.
+          //We send an event at the bottom of this function.
         } catch (const std::string &e) {
           asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
             "%s:%s: %s\n",
@@ -726,6 +724,9 @@ asynStatus AndorCCD::writeInt32(asynUser *pasynUser, epicsInt32 value)
       status = ADDriver::writeInt32(pasynUser, value);
     }
 
+    //For a successful write, clear the error message.
+    setStringParam(AndorMessage, " ");
+
     /* Do callbacks so higher layers see any changes */
     callParamCallbacks();
 
@@ -736,22 +737,18 @@ asynStatus AndorCCD::writeInt32(asynUser *pasynUser, epicsInt32 value)
       asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW, 
         "%s:%s:, Sending dataEvent to dataTask ...\n", 
         driverName, functionName);
-      // Also signal the data readout thread
+      //Also signal the data readout thread
       epicsEventSignal(dataEvent);
     }
 
-    if (status) {
+    if (status)
         asynPrint(pasynUser, ASYN_TRACE_ERROR,
               "%s:%s: error, status=%d function=%d, value=%d\n",
               driverName, functionName, status, function, value);
-    }
-    else {
+    else
         asynPrint(pasynUser, ASYN_TRACEIO_DRIVER,
               "%s:%s: function=%d, value=%d\n",
               driverName, functionName, function, value);
-        /* For a successful write, clear the error message. */
-        setStringParam(AndorMessage, " ");
-    }
     return status;
 }
 
@@ -1518,16 +1515,13 @@ void AndorCCD::dataTask(void)
           driverName, functionName);
         checkStatus(StartAcquisition());
         acquiring = 1;
-        asynPrint(pasynUserSelf, ASYN_TRACE_FLOW,
-          "%s:%s: Acquisition started\n",
-          driverName, functionName);
       } catch (const std::string &e) {
         asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
           "%s:%s: %s\n",
           driverName, functionName, e.c_str());
         continue;
       }
-      // Read some parameters
+      //Read some parameters
       getIntegerParam(NDDataType, &itemp); dataType = (NDDataType_t)itemp;
       getIntegerParam(NDAutoSave, &autoSave);
       getIntegerParam(NDArrayCallbacks, &arrayCallbacks);
@@ -1536,9 +1530,6 @@ void AndorCCD::dataTask(void)
       // Reset the counters
       setIntegerParam(ADNumImagesCounter, 0);
       setIntegerParam(ADNumExposuresCounter, 0);
-      callParamCallbacks();
-      // Set ADAcquire to 1
-      setIntegerParam(ADAcquire, 1);
       callParamCallbacks();
     } else {
       asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, 

--- a/andorApp/src/andorCCD.cpp
+++ b/andorApp/src/andorCCD.cpp
@@ -1490,7 +1490,7 @@ void AndorCCD::dataTask(void)
     
     errorString = NULL;
 
-    //Wait for event from main thread to signal that data acquisition has started.
+    // Wait for event from main thread to signal that data acquisition has started.
     this->unlock();
     status = epicsEventWait(dataEvent);
     if (mExiting)
@@ -1500,7 +1500,7 @@ void AndorCCD::dataTask(void)
       driverName, functionName);
     this->lock();
 
-    //Sanity check that main thread thinks we are acquiring data
+    // Sanity check that main thread thinks we are acquiring data
     if (mAcquiringData) {
       try {
         status = setupAcquisition();
@@ -1521,7 +1521,7 @@ void AndorCCD::dataTask(void)
           driverName, functionName, e.c_str());
         continue;
       }
-      //Read some parameters
+      // Read some parameters
       getIntegerParam(NDDataType, &itemp); dataType = (NDDataType_t)itemp;
       getIntegerParam(NDAutoSave, &autoSave);
       getIntegerParam(NDArrayCallbacks, &arrayCallbacks);
@@ -1638,14 +1638,14 @@ void AndorCCD::dataTask(void)
       ADDriver::setShutter(ADShutterClosed);
     }
 
-    //Now clear main thread flag
+    // Now clear main thread flag
     mAcquiringData = 0;
     setIntegerParam(ADAcquire, 0);
     //setIntegerParam(ADStatus, 0); //Dont set this as the status thread sets it.
 
     /* Call the callbacks to update any changes */
     callParamCallbacks();
-  } //End of loop
+  } // End of loop
   mExited++;
   this->unlock();
 }
@@ -1934,7 +1934,7 @@ done:
 }
 
 
-//C utility functions to tie in with EPICS
+// C utility functions to tie in with EPICS
 
 static void andorStatusTaskC(void *drvPvt)
 {

--- a/andorApp/src/andorCCD.cpp
+++ b/andorApp/src/andorCCD.cpp
@@ -634,6 +634,7 @@ asynStatus AndorCCD::writeInt32(asynUser *pasynUser, epicsInt32 value)
     if (function == ADAcquire) {
       getIntegerParam(ADStatus, &adstatus);
       if (value && (adstatus == ADStatusIdle)) {
+        // Start the acqusition here, then send an event to the dataTask at the end of this function
         try {
           // Set up acquisition
           mAcquiringData = 1;

--- a/andorApp/src/andorCCD.cpp
+++ b/andorApp/src/andorCCD.cpp
@@ -657,6 +657,7 @@ asynStatus AndorCCD::writeInt32(asynUser *pasynUser, epicsInt32 value)
           asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
             "%s:%s: %s\n",
             driverName, functionName, e.c_str());
+          status = asynError;
         }
       }
       if (!value && (adstatus != ADStatusIdle)) {
@@ -739,9 +740,6 @@ asynStatus AndorCCD::writeInt32(asynUser *pasynUser, epicsInt32 value)
       status = ADDriver::writeInt32(pasynUser, value);
     }
 
-    // For a successful write, clear the error message.
-    setStringParam(AndorMessage, " ");
-
     /* Do callbacks so higher layers see any changes */
     callParamCallbacks();
 
@@ -764,6 +762,8 @@ asynStatus AndorCCD::writeInt32(asynUser *pasynUser, epicsInt32 value)
         asynPrint(pasynUser, ASYN_TRACEIO_DRIVER,
               "%s:%s: function=%d, value=%d\n",
               driverName, functionName, function, value);
+        // For a successful write, clear the error message.
+        setStringParam(AndorMessage, " ");
     return status;
 }
 


### PR DESCRIPTION
Fix for #32.
Based on requested changes in #33.

- ADAcquire is set back to 0 in writeInt32
- dataTask sets ADAcquire to 1 after StartAcquisition() has been called followed up by callParamCallbacks()

I place the setting of ADAcquire above the line suggested as otherwise the parameter would be "set" every time in the while loop.

A couple of lines had DOS line endings in the source so these have been converted to Unix.