### PR TITLE
Added check in constructor before setting temperature

### DIFF
--- a/andorApp/src/andorCCD.cpp
+++ b/andorApp/src/andorCCD.cpp
@@ -244,10 +244,22 @@ AndorCCD::AndorCCD(const char *portName, const char *installPath, int cameraSeri
 
     /* Get current temperature */
     float temperature;
-    checkStatus(GetTemperatureF(&temperature));
-    printf("%s:%s: current temperature is %f\n", driverName, functionName, temperature);
-    setDoubleParam(ADTemperature, temperature);
-
+    int coolerStatus;
+    int maxTemp = 0;
+    int minTemp = 0;
+    checkStatus(IsCoolerOn(&coolerStatus));
+    if (coolerStatus){
+      checkStatus(GetTemperatureF(&temperature));
+      checkStatus(GetTemperatureRange(&minTemp, &maxTemp));
+      printf("%s:%s: current temperature is %f\n", driverName, functionName, temperature);
+      if (static_cast<int>(temperature) < minTemp) {
+        setDoubleParam(ADTemperature, minTemp);
+      } else if (static_cast<int>(temperature) < maxTemp) {
+        setDoubleParam(ADTemperature, maxTemp);
+      } else {
+        setDoubleParam(ADTemperature, temperature);
+      }
+    }
     callParamCallbacks();
   } catch (const std::string &e) {
     asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,


### PR DESCRIPTION
These changes build upon changes made by @BenBradnick in #31 ensuring that the constructor sets a temperature within the temperature limits, and only if the cooler is currently on. If the cooler is off, we do not assign a temperature. 