### PR TITLE
Update to correct WITH rather than USE

### DIFF
--- a/iocs/andorIOC/andorApp/src/Makefile
+++ b/iocs/andorIOC/andorApp/src/Makefile
@@ -6,7 +6,7 @@ include $(TOP)/configure/CONFIG
 # Note: we must built the application without GraphicsMagick.
 # This is because of a conflict with the Andor library (SetImage function) 
 # It leads to a build error on windows-x64, but to a run-time error on Linux.
-USE_GRAPHICSMAGICK=NO
+WITH_GRAPHICSMAGICK=NO
 
 PROD_NAME = andorCCDApp
 PROD_IOC_WIN32  += $(PROD_NAME)
@@ -22,14 +22,14 @@ $(PROD_NAME)_SRCS += $(PROD_NAME)_registerRecordDeviceDriver.cpp $(PROD_NAME)Mai
 # Add locally compiled object code
 PROD_LIBS       += andorCCD
 
-ifeq (win32-x86, $(findstring win32-x86, $(T_A)))
+ifneq (, $(findstring win32-x86, $(T_A)))
   PROD_LIBS  += atmcd32m
 
-else ifeq (windows-x64, $(findstring windows-x64, $(T_A)))
+else ifneq (, $(findstring windows-x64, $(T_A)))
   # Note: we must built the application without GraphicsMagick for windows-x64.  
   # This is because of a conflict with the Andor library (SetImage function) 
   # that only occurs on windows-x64.
-  USE_GRAPHICSMAGICK=NO
+  WITH_GRAPHICSMAGICK=NO
   PROD_LIBS  += atmcd64m
 endif
 PROD_LIBS_WIN32 += ShamrockCIFm


### PR DESCRIPTION
Updating as USE is old and WITH is the only way to get it to compile successfully if you have compiled ADCore with GraphicsMagick. Also modified the findstring method of confirming the target architecture as it could spit out multiple variations of windows-x64 or wind32-x86 such as -static, -mingw for instance.