### PR TITLE
Adds idle status notification to data thread

### DIFF
--- a/andorApp/src/andorCCD.h
+++ b/andorApp/src/andorCCD.h
@@ -198,6 +198,7 @@ class AndorCCD : public ADDriver {
 
   epicsEventId statusEvent;
   epicsEventId dataEvent;
+  epicsEventId idleEvent;
   double mPollingPeriod;
   double mFastPollingPeriod;
   unsigned int mAcquiringData;


### PR DESCRIPTION
I've had issues with Andor detectors getting stuck during an acquisition scan with gda when using ADAndor >2-7dls1 under epics R3.14.12.7 (no issue observed under epics R3.14.12.3 with ADAndor 2-6dls4).
This problem happens randomly, i.e not always for the same acquisition count, but on error it always displays the 'Acquire' flag ON with the detector status 'Idle'.
Investigating the problem in the driver with extra logs, I noticed a synchronization issue between the status thread and the data thread, where a new acquisition could be triggered by the gda client before the detector status had been reset to idle.
To overcome this problem, I've tried to prevent the acquisition to complete before the detector status had been updated. 