### PR TITLE
Only call SetVSAmplitude if the camera supports it. (Issue #49)

### DIFF
--- a/andorApp/src/andorCCD.cpp
+++ b/andorApp/src/andorCCD.cpp
@@ -1409,10 +1409,13 @@ asynStatus AndorCCD::setupAcquisition()
         driverName, functionName, verticalShiftPeriod);
     checkStatus(SetVSSpeed(verticalShiftPeriod));
 
-    asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW,
-        "%s:%s:, SetVSAmplitude(%d)\n",
-        driverName, functionName, verticalShiftAmplitude);
-    checkStatus(SetVSAmplitude(verticalShiftAmplitude));
+    if ((mCapabilities.ulSetFunctions & AC_SETFUNCTION_VSAMPLITUDE) != 0)
+    {
+        asynPrint(this->pasynUserSelf, ASYN_TRACE_FLOW,
+          "%s:%s:, SetVSAmplitude(%d)\n",
+          driverName, functionName, verticalShiftAmplitude);
+        checkStatus(SetVSAmplitude(verticalShiftAmplitude));
+    }
 
     switch (imageMode) {
       case ADImageSingle:


### PR DESCRIPTION
Uses the camera capabilities to determine whether the SetVSAmplitude can be called.
